### PR TITLE
Fix: Ensure correct JS syntax when replacing env vars in entrypoint.sh

### DIFF
--- a/ui/entrypoint.sh
+++ b/ui/entrypoint.sh
@@ -7,11 +7,31 @@ cd /app
 
 
 # Replace env variable placeholders with real values
+echo "Replacing environment variables..."
 printenv | grep NEXT_PUBLIC_ | while read -r line ; do
-  key=$(echo $line | cut -d "=" -f1)
-  value=$(echo $line | cut -d "=" -f2)
+  key=$(echo "$line" | cut -d "=" -f1)
+  value_raw=$(echo "$line" | cut -d "=" -f2-)
 
-  find .next/ -type f -exec sed -i "s|$key|$value|g" {} \;
+  # Escape backslashes and double quotes in the raw value to make it a valid JS string literal content
+  # Ensure that the final replacement is treated as a string literal in JS by quoting it.
+  js_string_value="\"$(echo "$value_raw" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')\""
+
+  # Construct sed expressions to replace:
+  # 1. process.env.KEY
+  # 2. process.env['KEY'] (single quotes)
+  # 3. process.env["KEY"] (double quotes)
+  # with "$js_string_value" (the actual JS string literal)
+
+  # Note: Using pipe '|' as the sed delimiter.
+  # The key itself (e.g., NEXT_PUBLIC_API_URL) is assumed to be a simple alphanumeric string
+  # and doesn't require further regex escaping in this specific context of sed patterns.
+
+  # Apply to .js and .html files in .next/ directory.
+  # Using find -print0 | xargs -0 for safer filename handling.
+  find .next/ \( -name "*.js" -o -name "*.html" \) -type f -print0 | xargs -0 sed -i \
+    -e "s|process\.env\.$key|$js_string_value|g" \
+    -e "s|process\.env\['$key'\]|$js_string_value|g" \
+    -e "s|process\.env\[\"$key\"\]|$js_string_value|g"
 done
 echo "Done replacing env variables NEXT_PUBLIC_ with real values"
 


### PR DESCRIPTION
The ui/entrypoint.sh script was modified to prevent JavaScript syntax errors that occurred when environment variable values (like URLs) were substituted directly into `process.env.KEY` expressions.

The script now correctly:
1. Escapes backslashes and double quotes within the environment variable values.
2. Wraps the processed value in double quotes to form a valid JavaScript string literal.
3. Uses `sed` to replace occurrences of `process.env.KEY`, `process.env['KEY']`, and `process.env["KEY"]` with this JavaScript string literal.

This ensures that the resulting code remains syntactically correct, addressing the "SyntaxError: Unexpected token ':'" error previously observed in your Next.js application's bundled files.