### PR TITLE
Fix: Make default config in DB respect environment variables

### DIFF
--- a/api/app/routers/config.py
+++ b/api/app/routers/config.py
@@ -42,26 +42,28 @@ class ConfigSchema(BaseModel):
     mem0: Mem0Config
 
 def get_default_configuration():
-    """Get the default configuration with sensible defaults for LLM and embedder."""
+    """Get the default configuration structure with 'env:VAR_NAME' placeholders."""
     return {
         "openmemory": {
-            "custom_instructions": None
+            "custom_instructions": "env:OPENMEMORY_CUSTOM_INSTRUCTIONS"
         },
         "mem0": {
             "llm": {
                 "provider": "openai",
                 "config": {
-                    "model": "gpt-4o-mini",
+                    "model": "env:OPENAI_MODEL",
                     "temperature": 0.1,
                     "max_tokens": 2000,
-                    "api_key": "env:OPENAI_API_KEY"
+                    "api_key": "env:OPENAI_API_KEY",
+                    "openai_base_url": "env:OPENAI_BASE_URL"
                 }
             },
             "embedder": {
                 "provider": "openai",
                 "config": {
-                    "model": "text-embedding-3-small",
-                    "api_key": "env:OPENAI_API_KEY"
+                    "model": "env:OPENAI_EMBEDDING_MODEL",
+                    "api_key": "env:OPENAI_EMBEDDING_MODEL_API_KEY",
+                    "openai_base_url": "env:OPENAI_EMBEDDING_MODEL_BASE_URL"
                 }
             }
         }


### PR DESCRIPTION
I modified the `get_default_configuration` function in `api/app/routers/config.py`. This function is responsible for seeding the 'main' configuration into the database if it doesn't exist.

Previously, it used hardcoded values for some fields (e.g., LLM model name defaulted to "gpt-4o-mini"), which would override settings intended to be controlled by environment variables (via .env files).

The function now uses "env:VAR_NAME" placeholders (e.g., "env:OPENAI_MODEL", "env:OPENAI_BASE_URL", "env:OPENAI_API_KEY") for these fields in the default configuration structure it returns. This ensures that when the database is seeded with this default, it stores references to environment variables.

These references are then resolved at runtime by the `_parse_environment_variables` function in `api/app/utils/memory.py`, making the application correctly use the values from the .env file (passed as environment variables to the container).

This resolves the issue where the application would incorrectly use "gpt-4o-mini" despite different settings in the .env file.